### PR TITLE
Changed keycloak config to use aanvrager wrapper

### DIFF
--- a/gzac-platform/imports/keycloak/portal-realm-gzac.json
+++ b/gzac-platform/imports/keycloak/portal-realm-gzac.json
@@ -611,7 +611,7 @@
           "user.attribute": "bsn",
           "id.token.claim": "true",
           "access.token.claim": "true",
-          "claim.name": "bsn",
+          "claim.name": "aanvrager.bsn",
           "jsonType.label": "String"
         }
       },
@@ -626,7 +626,7 @@
           "user.attribute": "kvk",
           "id.token.claim": "true",
           "access.token.claim": "true",
-          "claim.name": "kvk",
+          "claim.name": "aanvrager.kvk",
           "jsonType.label": "String"
         }
       }


### PR DESCRIPTION
Structure of expected JWT token changed from

```
{
    ...
    "bsn": "123456789"
}
```

to 

```
{
    ...
    "aanvrager": {
        "bsn": "123456789"
    }
}
```