### PR TITLE
Keycloak image updated (GZAC & Valtimo)

### DIFF
--- a/gzac-platform/docker-compose.yml
+++ b/gzac-platform/docker-compose.yml
@@ -6,7 +6,7 @@ services:
         container_name: gzac-portal-keycloak
         depends_on:
             - gzac-portal-keycloak-db
-        image: sleighzy/keycloak:15.0.2-arm64
+        image: quay.io/keycloak/keycloak:17.0.1-legacy
         volumes:
             - ./imports/keycloak:/opt/jboss/keycloak/imports
             - ./imports/keycloak/exports:/opt/jboss/keycloak/exports
@@ -75,7 +75,7 @@ services:
         container_name: valtimo-core-keycloak
         depends_on:
             - valtimo-core-keycloak-db
-        image: sleighzy/keycloak:15.0.2-arm64
+        image: quay.io/keycloak/keycloak:17.0.1-legacy
         volumes:
             - ./imports/keycloak:/opt/jboss/keycloak/imports
             - ./imports/keycloak/exports:/opt/jboss/keycloak/exports

--- a/gzac-platform/docker-compose.yml
+++ b/gzac-platform/docker-compose.yml
@@ -6,7 +6,7 @@ services:
         container_name: gzac-portal-keycloak
         depends_on:
             - gzac-portal-keycloak-db
-        image: jboss/keycloak:15.1.1
+        image: sleighzy/keycloak:15.0.2-arm64
         volumes:
             - ./imports/keycloak:/opt/jboss/keycloak/imports
             - ./imports/keycloak/exports:/opt/jboss/keycloak/exports
@@ -75,7 +75,7 @@ services:
         container_name: valtimo-core-keycloak
         depends_on:
             - valtimo-core-keycloak-db
-        image: jboss/keycloak:15.1.1
+        image: sleighzy/keycloak:15.0.2-arm64
         volumes:
             - ./imports/keycloak:/opt/jboss/keycloak/imports
             - ./imports/keycloak/exports:/opt/jboss/keycloak/exports
@@ -89,7 +89,6 @@ services:
             DB_ADDR: valtimo-core-keycloak-db
             DB_USER: keycloak
             DB_PASSWORD: keycloak
-
     valtimo-core-keycloak-db:
         image: postgres:14.1
         container_name: valtimo-core-keycloak-db

--- a/valtimo-platform/docker-compose.yml
+++ b/valtimo-platform/docker-compose.yml
@@ -18,7 +18,7 @@ services:
         container_name: valtimo-portal-keycloak
         depends_on:
             - valtimo-portal-keycloak -db
-        image: sleighzy/keycloak:15.0.2-arm64
+        image: quay.io/keycloak/keycloak:17.0.1-legacy
         volumes:
             - ./imports/keycloak:/opt/jboss/keycloak/imports
             - ./imports/keycloak/exports:/opt/jboss/keycloak/exports
@@ -76,7 +76,7 @@ services:
         container_name: valtimo-core-keycloak
         depends_on:
             - valtimo-core-keycloak-db
-        image: sleighzy/keycloak:15.0.2-arm64
+        image: quay.io/keycloak/keycloak:17.0.1-legacy
         volumes:
             - ./imports/keycloak:/opt/jboss/keycloak/imports
             - ./imports/keycloak/exports:/opt/jboss/keycloak/exports

--- a/valtimo-platform/docker-compose.yml
+++ b/valtimo-platform/docker-compose.yml
@@ -17,8 +17,8 @@ services:
     valtimo-portal-keycloak:
         container_name: valtimo-portal-keycloak
         depends_on:
-            - valtimo-portal-keycloak-db
-        image: jboss/keycloak:15.0.0
+            - valtimo-portal-keycloak -db
+        image: sleighzy/keycloak:15.0.2-arm64
         volumes:
             - ./imports/keycloak:/opt/jboss/keycloak/imports
             - ./imports/keycloak/exports:/opt/jboss/keycloak/exports
@@ -76,7 +76,7 @@ services:
         container_name: valtimo-core-keycloak
         depends_on:
             - valtimo-core-keycloak-db
-        image: jboss/keycloak:15.0.0
+        image: sleighzy/keycloak:15.0.2-arm64
         volumes:
             - ./imports/keycloak:/opt/jboss/keycloak/imports
             - ./imports/keycloak/exports:/opt/jboss/keycloak/exports

--- a/valtimo-platform/docker-compose.yml
+++ b/valtimo-platform/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     valtimo-portal-keycloak:
         container_name: valtimo-portal-keycloak
         depends_on:
-            - valtimo-portal-keycloak -db
+            - valtimo-portal-keycloak-db
         image: quay.io/keycloak/keycloak:17.0.1-legacy
         volumes:
             - ./imports/keycloak:/opt/jboss/keycloak/imports


### PR DESCRIPTION
Keycloak image 'jboss/keycloak:15.1.1' is replaced by 'sleighzy/keycloak:15.0.2-arm64'

Reason: Old image did not work (properly) on M1 macs
Change: Replaced old keycloak image (Jbos 15.1.1) by a new compatible image (Sleighzy 15.0.2)